### PR TITLE
adding option to always build all files.

### DIFF
--- a/lib/guard/asciidoc.rb
+++ b/lib/guard/asciidoc.rb
@@ -14,7 +14,8 @@ module Guard
       :eruby => 'erb',
       :doctype => 'article',
       :compact => false,
-      :attributes => {}
+      :attributes => {},
+      :always_build_all => false
     }
 
     def initialize(watchers = [], options = {})
@@ -61,10 +62,20 @@ module Guard
     def run_all
       # TODO is this too eager?
       # TODO does this honor the input path?
-      run_on_changes Watcher.match_files(self, Dir['*.{ad,asc,adoc,asciidoc}'])
+      run Watcher.match_files(self, Dir['*.{ad,asc,adoc,asciidoc}'])
     end
 
     def run_on_changes(paths)
+      opts = @options
+      
+      if opts[:always_build_all]
+        run_all
+      else
+        run paths
+      end
+    end
+
+    def run(paths)
       paths.each do |file_path|
         UI.info "Change detected: #{file_path}"
         opts = @options


### PR DESCRIPTION
I use a lot of inclusion in my projects and I find that the normal guard behavior of rebuilding just the changed file doesn't quite cut it. This looks like a fairly simple change to me.
