### PR TITLE
ignore-dot-files: add ignore_dot_files option

### DIFF
--- a/lib/guard/asciidoc.rb
+++ b/lib/guard/asciidoc.rb
@@ -16,7 +16,7 @@ module Guard
       :compact => false,
       :attributes => {},
       :always_build_all => false,
-      :ignore_dotfiles => true,
+      :ignore_hidden_files => true,
     }
 
     def initialize(watchers = [], options = {})
@@ -45,13 +45,13 @@ module Guard
         input_re = Regexp.escape merged_opts[:watch_dir]
       end
 
-      if merged_opts[:ignore_dotfiles]
-        ignore_dotfiles_re = '{0}[^.]'
+      if merged_opts[:ignore_hidden_files]
+        hidden_files_re = '{0}[^.]'
       else
-        ignore_dotfiles_re = ''
+        hidden_files_re = ''
       end
 
-      watch_re = %r{^#{input_re}.#{ignore_dotfiles_re}+\.(?:#{merged_opts[:watch_ext] * '|'})$}
+      watch_re = %r{^#{input_re}.#{hidden_files_re}+\.(?:#{merged_opts[:watch_ext] * '|'})$}
       watchers << ::Guard::Watcher.new(watch_re)
       merged_opts[:attributes] = {} unless merged_opts[:attributes]
       # set a flag to indicate running environment


### PR DESCRIPTION
I had an issue where whenever I save in Emacs, it briefly created a file `.#<filename>` for a given `<filename>`. This ends up matching the regex, but by the time guard attempts to open the file, it's been deleted, which ends up getting the `guard-asciidoc` watcher fired (removed) from the guard process. This creates an option to ignore dot files (fairly specific, but a reasonable request in my opinion.)

There is likely a better way to do this, and it may actually be more general to allow for a custom regex, but I'm don't dabble with Ruby very often, so this is the best I came up with. If you'd like to suggest a different way, I'd be happy to try and implement it and amend this PR.
